### PR TITLE
Prevent running the live preview action for PRs comming from forks

### DIFF
--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
     cleanup_preview:
+        if: github.event.pull_request.head.repo.full_name == github.repository
         name: Cleanup Preview
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
     deploy_preview:
+        if: github.event.pull_request.head.repo.full_name == github.repository
         name: Deploy Preview
         runs-on: ubuntu-latest
         env:


### PR DESCRIPTION
GitHub Secrets are not exposed on PRs that come from forked repositories for security reasons [1].

This behaviour leads to failed or hanging actions on our side because genezio cannot login properly.
This does not affect the `deploy` action though. I assume that actions triggered on a branch do not fall under the "not secure" category.

This PR prevents the live preview action running altogether from forked contributions.

https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow