### PR TITLE
docs: show local command env vars

### DIFF
--- a/docs/cli-tool/cli-commands/local.md
+++ b/docs/cli-tool/cli-commands/local.md
@@ -34,6 +34,7 @@ This command opens a local server for testing and debugging. The local server si
 When developing applications, you may need to specify custom ports for local execution. Genezio provides a way to define these ports using environment variables.
 
 The guide below outlines how to configure environment variables ensuring seamless local development.
+
 ### Environment Variables for SSR Ports
 
 The environment variable name is constructed as `GENEZIO_PORT_` followed by your framework name in uppercase (with special characters replaced by underscores.For example:

--- a/docs/cli-tool/cli-commands/local.md
+++ b/docs/cli-tool/cli-commands/local.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-description: Master the “genezio local” command to efficiently run and test your Genezio projects on your local machine. Optimize your development workflow with this guide
+description: Master the "genezio local" command to efficiently run and test your Genezio projects on your local machine. Optimize your development workflow with this guide
 ---
 
 # genezio local
@@ -18,7 +18,7 @@ This command opens a local server for testing and debugging. The local server si
 
 ### Options
 
-`-p, --port <port>`: Select a custom port for the local server. By default, the server is opened on port `8083`.
+`-p, --port <port>`: Select a custom port for the test interface genezio classes. By default, the server is opened on port `8083`.
 
 `--env <envFile>`: Let's you select a custom environment variables file to be used in your locally run project. If the argument is not specified, the file named `.env` will be used by default.
 
@@ -29,3 +29,31 @@ This command opens a local server for testing and debugging. The local server si
 `-h | --help`: Display a help message for more information on each argument and how to use it.
 
 `-s | --stage <stage>`: Set the stage on which you can test your services on the local server. This option will work as intended only if you are logged in. If you have services active on your deployed project, this option will allow you to test those services locally on the test interface. The default value is `prod`.
+
+### Environment Variables for SSR Ports
+
+The environment variable name is constructed as `GENEZIO_PORT_` followed by your framework name in uppercase (with special characters replaced by underscores.For example:
+
+- For Nest.js: `GENEZIO_PORT_NESTJS`
+- For Next.js: `GENEZIO_PORT_NEXTJS`
+- For Nitro: `GENEZIO_PORT_NITRO`
+- For Nuxt: `GENEZIO_PORT_NUXT`
+- For Remix: `GENEZIO_PORT_REMIX`
+- For Streamlit: `GENEZIO_PORT_STREAMLIT`
+
+You can set this environment variable using one of these methods:
+1. Add it to your `.env` file: `GENEZIO_PORT_<FRAMEWORK>=<port>`
+2. Windows: Run `set GENEZIO_PORT_<FRAMEWORK>=<port> && genezio local`
+3. macOS/Linux: Run `GENEZIO_PORT_<FRAMEWORK>=<port> genezio local`
+
+### Environment Variables for Functions
+
+For functions, the environment variable name is constructed by taking the function name, replacing any hyphens (-) with underscores (_), converting it to uppercase, and prefixing it with `GENEZIO_PORT_`. For example:
+
+- If your function is named `user-service`, the environment variable would be `GENEZIO_PORT_USER_SERVICE`
+- If your function is named `authHandler`, the environment variable would be `GENEZIO_PORT_AUTHHANDLER`
+
+You can set this environment variable using one of these methods:
+1. Add it to your `.env` file: `GENEZIO_PORT_<FUNCTION>=<port>`
+2. Windows: Run `set GENEZIO_PORT_<FUNCTION>=<port> && genezio local`
+3. macOS/Linux: Run `GENEZIO_PORT_<FUNCTION>=<port> genezio local`

--- a/docs/cli-tool/cli-commands/local.md
+++ b/docs/cli-tool/cli-commands/local.md
@@ -29,7 +29,11 @@ This command opens a local server for testing and debugging. The local server si
 `-h | --help`: Display a help message for more information on each argument and how to use it.
 
 `-s | --stage <stage>`: Set the stage on which you can test your services on the local server. This option will work as intended only if you are logged in. If you have services active on your deployed project, this option will allow you to test those services locally on the test interface. The default value is `prod`.
+## Set custom ports for testing locally
 
+When developing applications, you may need to specify custom ports for local execution. Genezio provides a way to define these ports using environment variables.
+
+The guide below outlines how to configure environment variables ensuring seamless local development.
 ### Environment Variables for SSR Ports
 
 The environment variable name is constructed as `GENEZIO_PORT_` followed by your framework name in uppercase (with special characters replaced by underscores.For example:

--- a/docs/cli-tool/cli-commands/local.md
+++ b/docs/cli-tool/cli-commands/local.md
@@ -52,7 +52,7 @@ You can set this environment variable using one of these methods:
 
 ### Environment Variables for Functions
 
-For functions, the environment variable name is constructed by taking the function name, replacing any hyphens (-) with underscores (_), converting it to uppercase, and prefixing it with `GENEZIO_PORT_`. For example:
+For functions, the environment variable name is constructed by taking the function name set in the `genezio.yaml`, replacing any hyphens (-) with underscores (_), converting it to uppercase, and prefixing it with `GENEZIO_PORT_`. For example:
 
 - If your function is named `user-service`, the environment variable would be `GENEZIO_PORT_USER_SERVICE`
 - If your function is named `authHandler`, the environment variable would be `GENEZIO_PORT_AUTHHANDLER`

--- a/docs/cli-tool/cli-commands/local.md
+++ b/docs/cli-tool/cli-commands/local.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-description: Master the "genezio local" command to efficiently run and test your Genezio projects on your local machine. Optimize your development workflow with this guide
+description: Master the `genezio local` command to efficiently run and test your Genezio projects on your local machine. Optimize your development workflow with this guide
 ---
 
 # genezio local


### PR DESCRIPTION
Add detailed documentation about environment variables for SSR ports and functions in the `genezio local` command.

- Explain environment variable format for SSR frameworks
- Add examples for different frameworks
- Document environment variable format for functions
- Include methods for setting environment variables